### PR TITLE
Configure EAS updates

### DIFF
--- a/apps/expo/App.tsx
+++ b/apps/expo/App.tsx
@@ -3,12 +3,15 @@ import React from 'react'
 import { NativeNavigation } from 'app/navigation/native'
 import { Provider } from 'app/provider'
 import { useFonts } from 'expo-font'
+import { useExpoUpdates } from './lib/useExpoUpdates'
 
 export default function App() {
   const [loaded] = useFonts({
     Inter: require('@tamagui/font-inter/otf/Inter-Medium.otf'),
     InterBold: require('@tamagui/font-inter/otf/Inter-Bold.otf'),
   })
+
+  useExpoUpdates(3)
 
   if (!loaded) {
     return null

--- a/apps/expo/lib/checkForUpdatesSimple.ts
+++ b/apps/expo/lib/checkForUpdatesSimple.ts
@@ -1,0 +1,16 @@
+import * as Updates from 'expo-updates'
+import { Alert, Platform } from 'react-native'
+
+export const checkForUpdatesSimple = async () => {
+  if (__DEV__ || Platform.OS === 'web') return
+  const check = await Updates.checkForUpdateAsync()
+  if (check.isAvailable) {
+    try {
+      await Updates.fetchUpdateAsync()
+      Alert.alert('Updating')
+      await Updates.reloadAsync()
+    } catch (e) {
+      console.log(e)
+    }
+  }
+}

--- a/apps/expo/lib/useExpoUpdates.ts
+++ b/apps/expo/lib/useExpoUpdates.ts
@@ -1,0 +1,10 @@
+import { checkForUpdatesSimple } from './checkForUpdatesSimple'
+import useInterval from './useInterval'
+
+export const useExpoUpdates = (seconds: number) => {
+  useInterval(
+    () => checkForUpdatesSimple(),
+    // Delay in milliseconds or null to stop it
+    seconds * 1000
+  )
+}

--- a/apps/expo/lib/useInterval.ts
+++ b/apps/expo/lib/useInterval.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react'
+// See: https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect'
+
+function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback)
+
+  // Remember the latest callback if it changes.
+  useIsomorphicLayoutEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  // Set up the interval.
+  useEffect(() => {
+    // Don't schedule if no delay is specified.
+    // Note: 0 is a valid value for delay.
+    if (!delay && delay !== 0) {
+      return
+    }
+
+    const id = setInterval(() => savedCallback.current(), delay)
+
+    return () => clearInterval(id)
+  }, [delay])
+}
+
+export default useInterval

--- a/apps/expo/lib/useIsomorphicLayoutEffect.ts
+++ b/apps/expo/lib/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+export default useIsomorphicLayoutEffect

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -37,7 +37,8 @@
     "web": "TAMAGUI_TARGET=web yarn expo start --web",
     "build:ios": "npx eas-cli build -p ios",
     "build:ios:local": "npx eas-cli build --platform ios --local",
-    "submit:ios": "npx eas-cli submit -p ios"
+    "submit:ios": "npx eas-cli submit -p ios",
+    "publish:ios": "npx eas-cli update --branch production -p ios --message 'Update'"
   },
   "main": "index.js",
   "version": "1.0.0",


### PR DESCRIPTION
Already had the EAS project config set up - this mainly adds the `useExpoUpdates` which checks for updates every 3 seconds instead of the default config of downloading only in the background and updating on next open.

Every 3 seconds will be excessive when we launch but good for now.